### PR TITLE
Make DA trigger only when needed

### DIFF
--- a/body.py
+++ b/body.py
@@ -808,7 +808,7 @@ if event.command in ['PRIVMSG']:
     for x in damatches:
         try:
             consumer = oembed.OEmbedConsumer()
-            endpoint = oembed.OEmbedEndpoint('http://backend.deviantart.com/oembed', ['http://*.deviantart.com/art/*', 'http://fav.me/*', 'http://sta.sh/*', 'http://*.deviantart.com/*#/d*'])
+            endpoint = oembed.OEmbedEndpoint('http://backend.deviantart.com/oembed', ['http://fav.me/*', 'http://sta.sh/*', 'http://*.deviantart.com/*#/d*'])
             consumer.addEndpoint(endpoint)
             response = consumer.embed(x).getData()
             out=[]


### PR DESCRIPTION
DA info should only trigger when the info isn't already in the URL to avoid spam
