### PR TITLE
Fixed issue for google commands with banned words

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -3,6 +3,7 @@ import HTMLParser,re,json,random,requests,datetime,socket,os,sys,oembed,urllib2,
 from ircutils import format
 import lxml.etree as etree
 import wikipedia as wiki
+import re
 from time import strftime
 from datetime import tzinfo,timedelta
 
@@ -15,12 +16,28 @@ def register(tag, value):
         return wrapped_f
     return wrapped
 
+def is_str_allowed(str,bannedwords):
+    for pattern in bannedwords:
+        escapedv=re.escape(pattern)
+        escapedv=escapedv.replace('\\*','.*')
+        matches=re.search(escapedv,str)
+        if matches:
+            return False
+    return True
+    
+def is_all_str_allowed(strs,bannedwords):
+    for str in strs:
+        if not is_str_allowed(str,bannedwords):
+            return False
+    return True
+    
 class commands:
-    def __init__(self, send_message, send_action, config):
+    def __init__(self, send_message, send_action, banned_words, config):
         self.send_message = send_message
         self.config = config
         self.send_action = send_action
-
+        self.banned_words=banned_words
+        
     def regex_yt(self, event):
         ytmatch=re.compile(
             "https?:\/\/(?:[0-9A-Z-]+\.)?(?:youtu\.be\/|youtube\.com\S*[^\w\-\s"
@@ -121,7 +138,11 @@ class commands:
             t = requests.get(
                 'https://www.googleapis.com/customsearch/v1',
                 params=dict(q=event.params, cx=self.config['googleengine'], key=self.config['googleKey'], safe='off')
-                ).json()['items'][0]
+                ).json()
+            index=0
+            while(len(t['items'])>index+1 and not is_all_str_allowed([t['items'][index]['title'],t['items'][index]['link']],self.banned_words)):
+                index+=1
+            t=t['items'][index]
             self.send_message(
                 event.respond,
                 u'{}: {}'.format(
@@ -374,7 +395,11 @@ class commands:
             t = requests.get(
                 'https://www.googleapis.com/customsearch/v1',
                 params=dict(q=event.params, cx=self.config['googleengine'], key=self.config['googleKey'], safe='off', searchType='image')
-                ).json()['items'][0]
+                ).json()
+            index=0
+            while(len(t['items'])>index+1 and not is_all_str_allowed([t['items'][index]['title'],t['items'][index]['link']],self.banned_words)):
+                index+=1
+            t=t['items'][index]
             self.send_message(
                 event.respond,
                 u'{}: {}'.format(

--- a/main.py
+++ b/main.py
@@ -4,6 +4,12 @@ import time,datetime,os,commands,custom_commands
 
 
 class berry(bot.SimpleBot):
+  def __init__(self, config):
+        nick=config['nick'].encode('ascii', 'replace')
+        bot.SimpleBot.__init__(self, nick)
+        self.config=config
+        self.banned_words=set()
+        self.checking_for_banned_words=0
   def command_help(self, event):
     '''Usage: ~help <command> The fuck do you think it does?'''
     #Get commands with documentation
@@ -27,7 +33,7 @@ class berry(bot.SimpleBot):
     reload(custom_commands)
 
     #Create objects for commands and custom_commands
-    cmd = commands.commands(self.send_message, self.send_action, self.config)
+    cmd = commands.commands(self.send_message, self.send_action, self.banned_words, self.config)
     cust_cmd = custom_commands.custom_commands(self.send_message, self.send_action, self.config)
 
     #Method to get all callable objects with a given prefix from a given object
@@ -58,7 +64,7 @@ class berry(bot.SimpleBot):
     #Execute regexes
     for regex in self.regexes:
       self.regexes[regex](event)
-        
+      
     #Execute command
     if event.command[0] in self.config['prefixes'].split() and 'command_%s' % event.command[1:].lower() in self.cmds:
       comm = self.cmds['command_%s' % event.command[1:].lower()]
@@ -71,8 +77,29 @@ class berry(bot.SimpleBot):
       event.respond = event.target if event.target != self.nickname else event.source
       
       if not event.source == self.nickname:
-        if event.command == "INVITE":
+        if event.command == 'INVITE':
           self.join_channel(event.params[0])
+          
+        #after joining a channel, send mode g command to check for banned words
+        if event.command == "RPL_ENDOFNAMES":
+            channel=event.params[0]
+            self.checking_for_banned_words+=1
+            self.execute("MODE",channel,"g")
+            
+        #take banned words from server messages
+        if is_int(event.command) and self.checking_for_banned_words>0: 
+            if len(event.params)==4 and event.params[0] in config['channels'].split(',') and is_int(event.params[3]):
+                self.banned_words.add(event.params[1])
+            if len(event.params)==2 and event.params[1]=='End of channel spamfilter list':
+                self.checking_for_banned_words-=1
+                
+        #update banned word list when someone uses mode +/-g
+        if event.command == 'MODE' and len(event.params)>=2:
+            if event.params[0]=='+g':
+                self.banned_words.add(event.params[1])
+            if event.params[0]=='-g' and event.params[1] in self.banned_words:
+                self.banned_words.remove(event.params[1])
+                
         if event.command in ['PRIVMSG']:
           self.privmsg(event)
 
@@ -102,12 +129,18 @@ def loadconf(filename):
     with open(filename, 'w') as conffile:
       json.dump(defaultConf,conffile, sort_keys=True, indent=4, separators=(',',': '))
       return defaultConf
+      
+def is_int(s):
+    try:
+        int(s)
+    except ValueError:
+        return False
+    return True
 
 if __name__ == "__main__":
   config = loadconf("config.json")
-  s=berry(config['nick'].encode('ascii', 'replace'))
+  s=berry(config)
   s.connect(config['server'].encode('ascii', 'replace'), channel=config['channels'].encode('ascii', 'replace'), use_ssl=False)
-  s.config = config
   s.lastloadconf = 0
   s.lastloadcommands = 0
   s.lastloadcustomcommands = 0


### PR DESCRIPTION
Maintains a list of banned words. On a g or gimg command, instead of always using the first search result, instead uses the first search result that does not match any word bans.